### PR TITLE
fix bugs : background and cover ，Heavyweight update: Rewrite button jump logic

### DIFF
--- a/button_index.json
+++ b/button_index.json
@@ -1,0 +1,32 @@
+{
+    "menuToggle": {
+        "id": "menu-toggle",
+        "class": "menu-toggle",
+        "display": "block"
+    },
+    "modal": {
+        "id": "modal",
+        "display": "none"
+    },
+    "closeButton": {
+        "class": "close-button"
+    },
+    "modalContent": {
+        "class": "modal-content",
+        "showClass": "show"
+    },
+    "animations": {
+        "showDelay": 20,
+        "hideDelay": 400
+    },
+    "links": [
+        { "text": "", "href": "" },
+        { "text": "网站首页", "href": "./index.html" },
+        { "text": "加入服务器", "href": "./static/join.html" },
+        { "text": "服务器公告", "href": "./static/notice.html" },
+        { "text": "服务器教程", "href": "./static/teach.html" },
+        { "text": "服务器更新内容预告", "href": "./static/update.html" },
+        { "text": "赛应斯地区游客留言", "href": "./static/pokemon_master.html" },
+        { "text": "版权声明与特别鸣谢", "href": "./static/thanks.html" }
+    ]
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Lemon-Tea</title>
     <link rel="icon" type="image/png" href="./static/images/favicon.ico" />
     <link rel="stylesheet" href="./static/css/style.css">
-    <script src="./static/js/main.js" defer></script>
+    <script src="./static/js/button_index.js" defer></script>
     <script src="./static/js/background.js" defer></script>
 </head>
 <body>
@@ -50,19 +50,11 @@
     </main>
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="./index.html">网站首页</a></li>
-                <li><a href="./static/join.html">加入服务器</a></li>
-                <li><a href="./static/notice.html">服务器公告</a></li>
-                <li><a href="./static/teach.html">服务器教程</a></li>
-                <li><a href="./static/update.html">服务器更新内容预告</a></li>
-                <li><a href="./static/pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./static/thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,8 @@
     </section>
     <section class="hero">
       <div class="overlay" style="background-image: url('./static/images/background/sub-background4.webp');">
-          <h2>网站说明</h2>
-          <p>想要为网站做出贡献？<br /><a href="https://github.com/LIUYISENGDEGE-LemonTea/LIUYISENGDEGE-LemonTea.github.io" target="_blank">点击前往本网站Github仓库！</a>
-            <br /><br />网站页面设计：<a href="https://al2so43.pages.dev/" target="_blank">Al2(SO4)3-硫酸铝</a></p>
+          <h2>介绍4！</h2>
+          <p>这里是Lemon-Tea服务器的官网！</p>
       </div>
   </section>
     </main>

--- a/static/article/button_article.json
+++ b/static/article/button_article.json
@@ -1,0 +1,32 @@
+{
+    "menuToggle": {
+        "id": "menu-toggle",
+        "class": "menu-toggle",
+        "display": "block"
+    },
+    "modal": {
+        "id": "modal",
+        "display": "none"
+    },
+    "closeButton": {
+        "class": "close-button"
+    },
+    "modalContent": {
+        "class": "modal-content",
+        "showClass": "show"
+    },
+    "animations": {
+        "showDelay": 20,
+        "hideDelay": 400
+    },
+    "links": [
+        { "text": "", "href": "" },
+        { "text": "网站首页", "href": "../../../../index.html" },
+        { "text": "加入服务器", "href": "../../../join.html" },
+        { "text": "服务器公告", "href": "../../../notice.html" },
+        { "text": "服务器教程", "href": "../../../teach.html" },
+        { "text": "服务器更新内容预告", "href": "../../../update.html" },
+        { "text": "赛应斯地区游客留言", "href": "../../../pokemon_master.html" },
+        { "text": "版权声明与特别鸣谢", "href": "../../../thanks.html" }
+    ]
+}

--- a/static/article/join/1-explain/index.html
+++ b/static/article/join/1-explain/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -30,19 +30,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/notice/1-explain/index.html
+++ b/static/article/notice/1-explain/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -30,19 +30,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/pokemon_master/1-explain/index.html
+++ b/static/article/pokemon_master/1-explain/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -30,19 +30,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/teach/1-explain/index.html
+++ b/static/article/teach/1-explain/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -30,19 +30,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/thanks/1-thanks/index.html
+++ b/static/article/thanks/1-thanks/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -34,19 +34,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/thanks/2-copyright/index.html
+++ b/static/article/thanks/2-copyright/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -383,7 +383,6 @@ Creative Commons Notice
     this trademark restriction does not form part of the License.
 
     Creative Commons may be contacted at https://creativecommons.org/.
-
             </p></strong>
             </div>
         </div>
@@ -391,19 +390,11 @@ Creative Commons Notice
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-               <li></li>
-               <li><a href="../../../../index.html">网站首页</a></li>
-               <li><a href="../../../join.html">加入服务器</a></li>
-               <li><a href="../../../notice.html">服务器公告</a></li>
-               <li><a href="../../../teach.html">服务器教程</a></li>
-               <li><a href="../../../update.html">服务器更新内容预告</a></li>
-               <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-               <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/thanks/3-authorization/index.html
+++ b/static/article/thanks/3-authorization/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -33,19 +33,11 @@ Hinhin1008last向Addon作者Zacek el Serpentín申请后，Addon作者给予本�
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/article/update/1-explain/index.html
+++ b/static/article/update/1-explain/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="../../../images/favicon.ico" />
     <link rel="stylesheet" href="../../../css/style.css">
     <link rel="stylesheet" href="../../../css/article.css">
-    <script src="../../../js/main.js" defer></script>
+    <script src="../../../js/button_article.js" defer></script>
 </head>
 <body>
     <header>
@@ -30,19 +30,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../../../../index.html">网站首页</a></li>
-                <li><a href="../../../join.html">加入服务器</a></li>
-                <li><a href="../../../notice.html">服务器公告</a></li>
-                <li><a href="../../../teach.html">服务器教程</a></li>
-                <li><a href="../../../update.html">服务器更新内容预告</a></li>
-                <li><a href="../../../pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="../../../thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/button_static.json
+++ b/static/button_static.json
@@ -1,0 +1,32 @@
+{
+    "menuToggle": {
+        "id": "menu-toggle",
+        "class": "menu-toggle",
+        "display": "block"
+    },
+    "modal": {
+        "id": "modal",
+        "display": "none"
+    },
+    "closeButton": {
+        "class": "close-button"
+    },
+    "modalContent": {
+        "class": "modal-content",
+        "showClass": "show"
+    },
+    "animations": {
+        "showDelay": 20,
+        "hideDelay": 400
+    },
+    "links": [
+        { "text": "", "href": "" },
+        { "text": "网站首页", "href": "../index.html" },
+        { "text": "加入服务器", "href": "./join.html" },
+        { "text": "服务器公告", "href": "./notice.html" },
+        { "text": "服务器教程", "href": "./teach.html" },
+        { "text": "服务器更新内容预告", "href": "./update.html" },
+        { "text": "赛应斯地区游客留言", "href": "./pokemon_master.html" },
+        { "text": "版权声明与特别鸣谢", "href": "./thanks.html" }
+    ]
+}

--- a/static/css/article.css
+++ b/static/css/article.css
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 .article-list {
     display: flex;
     flex-direction: row; 
@@ -105,4 +107,56 @@
 .sub-title {
     font-size: 1.1rem;
     text-align: center;
+}
+
+.article-list {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding: 20px;
+    gap: 15px;
+    justify-content: flex-start;
+}
+
+@media (min-width: 670px) {
+    .article-list {
+        justify-content: center;
+    }
+    .article-item {
+        flex: 1 1 calc((100% - 1 * 15px) / 2 - 15px);  
+        margin: 0 7.5px;  
+    }
+}
+
+@media (min-width: 980px) {
+    .article-item {
+        flex: 1 1 calc((100% - 2 * 15px) / 3 - 15px);  
+        margin: 0 7.5px;  
+    }
+}
+
+@media (min-width: 1200px) {
+    .article-item {
+        flex: 1 1 calc((100% - 2 * 15px) / 3 - 15px);  
+        margin: 0 7.5px;  
+    }
+}
+
+@media (max-width: 670px) {
+    .article-item {
+        width: 100%;
+        margin: 0;
+    }
+}
+
+@media (min-width: 670px) and (max-width: 1200px) {
+    .article-list {
+        justify-content: center;
+    }
+    .article-item {
+        width: calc((100% - 1 * 15px) / 2);
+    }
+    .article-list:has(.article-item:only-child) {
+        justify-content: center;
+    }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,8 @@
+@charset "UTF-8";
+
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
+    font-family: 'Arial', sans-serif;
 }
 
 
@@ -53,6 +55,10 @@ header {
     text-align: center;
     color: white;
     background-color: rgba(0, 0, 0, 0.5);
+    background-size: cover; 
+    background-repeat: no-repeat; 
+    background-position: center; 
+    padding: 1.15rem;
 }
 
 .modal {
@@ -125,6 +131,7 @@ footer {
     padding: 1rem;
     background-color: #333;
     color: white;
+    font-size: 0.9rem;
 }
 
 

--- a/static/join.html
+++ b/static/join.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -35,19 +35,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/js/button_article.js
+++ b/static/js/button_article.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const menuToggle = document.querySelector('.menu-toggle');
+    const modal = document.getElementById('modal');
+    const closeButton = document.querySelector('.close-button');
+    const modalContent = document.querySelector('.modal-content');
+    const dynamicMenu = document.getElementById('dynamic-menu'); 
+    menuToggle.style.display = 'block';
+
+    menuToggle.addEventListener('click', function () {
+        modal.style.display = 'block';
+        setTimeout(() => {
+            modalContent.classList.add('show');
+        }, 20);
+        menuToggle.style.display = 'none';
+    });
+
+    closeButton.addEventListener('click', function () {
+        modalContent.classList.remove('show');
+        setTimeout(() => {
+            modal.style.display = 'none';
+            menuToggle.style.display = 'block';
+        }, 400);
+    });
+
+    window.addEventListener('click', function (event) {
+        if (event.target === modal) {
+            modalContent.classList.remove('show');
+            setTimeout(() => {
+                modal.style.display = 'none';
+                menuToggle.style.display = 'block';
+            }, 400);
+        }
+    });
+
+    fetch('../../button_article.json')
+        .then(response => response.json())
+        .then(config => {
+            config.links.forEach(link => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = link.href;
+                a.textContent = link.text;
+                li.appendChild(a);
+                dynamicMenu.appendChild(li);
+            });
+        })
+        .catch(error => console.error('Error loading button:', error));
+});

--- a/static/js/button_index.js
+++ b/static/js/button_index.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const menuToggle = document.querySelector('.menu-toggle');
+    const modal = document.getElementById('modal');
+    const closeButton = document.querySelector('.close-button');
+    const modalContent = document.querySelector('.modal-content');
+    const dynamicMenu = document.getElementById('dynamic-menu'); 
+
+    menuToggle.style.display = 'block';
+
+    menuToggle.addEventListener('click', function () {
+        modal.style.display = 'block';
+        setTimeout(() => {
+            modalContent.classList.add('show');
+        }, 20);
+        menuToggle.style.display = 'none';
+    });
+
+    closeButton.addEventListener('click', function () {
+        modalContent.classList.remove('show');
+        setTimeout(() => {
+            modal.style.display = 'none';
+            menuToggle.style.display = 'block';
+        }, 400);
+    });
+
+    window.addEventListener('click', function (event) {
+        if (event.target === modal) {
+            modalContent.classList.remove('show');
+            setTimeout(() => {
+                modal.style.display = 'none';
+                menuToggle.style.display = 'block';
+            }, 400);
+        }
+    });
+
+    fetch('./button_index.json')
+        .then(response => response.json())
+        .then(config => {
+            config.links.forEach(link => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = link.href;
+                a.textContent = link.text;
+                li.appendChild(a);
+                dynamicMenu.appendChild(li);
+            });
+        })
+        .catch(error => console.error('Error loading button:', error));
+});

--- a/static/js/button_static.js
+++ b/static/js/button_static.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const menuToggle = document.querySelector('.menu-toggle');
+    const modal = document.getElementById('modal');
+    const closeButton = document.querySelector('.close-button');
+    const modalContent = document.querySelector('.modal-content');
+    const dynamicMenu = document.getElementById('dynamic-menu'); 
+
+    menuToggle.style.display = 'block';
+
+    menuToggle.addEventListener('click', function () {
+        modal.style.display = 'block';
+        setTimeout(() => {
+            modalContent.classList.add('show');
+        }, 20);
+        menuToggle.style.display = 'none';
+    });
+
+    closeButton.addEventListener('click', function () {
+        modalContent.classList.remove('show');
+        setTimeout(() => {
+            modal.style.display = 'none';
+            menuToggle.style.display = 'block';
+        }, 400);
+    });
+
+    window.addEventListener('click', function (event) {
+        if (event.target === modal) {
+            modalContent.classList.remove('show');
+            setTimeout(() => {
+                modal.style.display = 'none';
+                menuToggle.style.display = 'block';
+            }, 400);
+        }
+    });
+
+    fetch('./button_static.json')
+        .then(response => response.json())
+        .then(config => {
+            config.links.forEach(link => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = link.href;
+                a.textContent = link.text;
+                li.appendChild(a);
+                dynamicMenu.appendChild(li);
+            });
+        })
+        .catch(error => console.error('Error loading button:', error));
+});

--- a/static/notice.html
+++ b/static/notice.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -35,19 +35,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/pokemon_master.html
+++ b/static/pokemon_master.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -35,19 +35,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/teach.html
+++ b/static/teach.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -35,19 +35,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/thanks.html
+++ b/static/thanks.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -43,19 +43,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>

--- a/static/update.html
+++ b/static/update.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="./images/favicon.ico" />
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/article.css">
-    <script src="./js/main.js" defer></script>
+    <script src="./js/button_static.js" defer></script>
 </head>
 <body>
     <header>
@@ -35,19 +35,11 @@
     
 
     <div class="modal" id="modal">
-        <div class="modal-content">
-            <span class="close-button">&times;</span>
-            <ul>
-                <li></li>
-                <li><a href="../index.html">网站首页</a></li>
-                <li><a href="./join.html">加入服务器</a></li>
-                <li><a href="./notice.html">服务器公告</a></li>
-                <li><a href="./teach.html">服务器教程</a></li>
-                <li><a href="./update.html">服务器更新内容预告</a></li>
-                <li><a href="./pokemon_master.html">赛应斯地区游客留言</a></li>
-                <li><a href="./thanks.html">版权声明与特别鸣谢</a></li>
-            </ul>
-        </div>
+    <div class="modal-content">
+        <span class="close-button">&times;</span>
+        <ul id="dynamic-menu">
+        </ul>
+    </div>
     </div>
 
     <footer>


### PR DESCRIPTION
第一条提交（eb12f49）：莫名其妙地修复了莫名其妙的细节BUG（其实就是壁纸图片在极端屏幕下现实的问题，这里倾向尽可能兼容地显示，理论上不影响正常使用）
第二条提交（21da7ea）：这是一次重量级更新，我设法优化了按钮跳转逻辑，由于其分为三级（主界面，大模块类型，文章），我创建三个JSON文件以及对应的JS，使其可以通过读取JSON来设置按钮菜单跳转列表。这是因为其大部分跳转列表实际上被设置为统一的，导致以往的每个HTML都需要单独设定一样的重复内容，需要更改时十分麻烦，那么如果能这么保持三段分级，并且没什么特殊要求，那么这将十分高效，因为只需更改一个文件就可以完成同级别的更改了。

番外：我看见你们的宣传视频了( https://www.bilibili.com/video/BV1EWt4zfE3u/ )，看来你们已经开服了，我也据zhigua所说了解了一些消息，只能说未来的路很长，希望你们可以保持本心地走下去

说明：我并不打算设置文章的预设CSS内容，大多数情况常规已经够用了，少部分情况自行在该HTML文件设置即可